### PR TITLE
Encode/decode c-style hex

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -23,5 +23,7 @@
     { "command": "xml", "args": {"encode_type": "escape"}, "caption": "Codec: XML escape" },
     { "command": "xml", "args": {"encode_type": "unescape"}, "caption": "Codec: XML unescape" },
     { "command": "quoted_printable", "args": {"encode_type": "encode"}, "caption": "Codec: Quoted-Printable encode" },
-    { "command": "quoted_printable", "args": {"encode_type": "decode"}, "caption": "Codec: Quoted-Printable decode" }
+    { "command": "quoted_printable", "args": {"encode_type": "decode"}, "caption": "Codec: Quoted-Printable decode" },
+    { "command": "c_hex", "args": {"encode_type": "encode"}, "caption": "Codec: C-style Hex encode" },
+    { "command": "c_hex", "args": {"encode_type": "decode"}, "caption": "Codec: C-style Hex decode" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -24,6 +24,6 @@
     { "command": "xml", "args": {"encode_type": "unescape"}, "caption": "Codec: XML unescape" },
     { "command": "quoted_printable", "args": {"encode_type": "encode"}, "caption": "Codec: Quoted-Printable encode" },
     { "command": "quoted_printable", "args": {"encode_type": "decode"}, "caption": "Codec: Quoted-Printable decode" },
-    { "command": "c_hex", "args": {"encode_type": "encode"}, "caption": "Codec: C-style Hex encode" },
-    { "command": "c_hex", "args": {"encode_type": "decode"}, "caption": "Codec: C-style Hex decode" }
+    { "command": "hex", "args": {"encode_type": "encode"}, "caption": "Codec: C-style Hex encode" },
+    { "command": "hex", "args": {"encode_type": "decode"}, "caption": "Codec: C-style Hex decode" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -24,6 +24,6 @@
     { "command": "xml", "args": {"encode_type": "unescape"}, "caption": "Codec: XML unescape" },
     { "command": "quoted_printable", "args": {"encode_type": "encode"}, "caption": "Codec: Quoted-Printable encode" },
     { "command": "quoted_printable", "args": {"encode_type": "decode"}, "caption": "Codec: Quoted-Printable decode" },
-    { "command": "hex", "args": {"encode_type": "encode"}, "caption": "Codec: C-style Hex encode" },
-    { "command": "hex", "args": {"encode_type": "decode"}, "caption": "Codec: C-style Hex decode" }
+    { "command": "hex", "args": {"encode_type": "encode"}, "caption": "Codec: C-style Hex encode (ascii)" },
+    { "command": "hex", "args": {"encode_type": "decode"}, "caption": "Codec: C-style Hex decode (ascii)" }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -77,12 +77,12 @@
                         ]
                     },
                     {
-                        "caption": "Hex",
+                        "caption": "Code Point",
                         "mnemonic": "C",
                         "children":
                         [
-                            { "command": "hex", "args": {"encode_type": "encode"}, "caption": "C-style Hex encode" },
-                            { "command": "hex", "args": {"encode_type": "decode"}, "caption": "C-style Hex decode" }
+                            { "command": "hex", "args": {"encode_type": "encode"}, "caption": "C-style Hex encode (ascii)" },
+                            { "command": "hex", "args": {"encode_type": "decode"}, "caption": "C-style Hex decode (ascii)" }
                         ]
                     }
                 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -81,8 +81,8 @@
                         "mnemonic": "C",
                         "children":
                         [
-                            { "command": "c_hex", "args": {"encode_type": "encode"}, "caption": "C-style Hex encode" },
-                            { "command": "c_hex", "args": {"encode_type": "decode"}, "caption": "C-style Hex decode" }
+                            { "command": "hex", "args": {"encode_type": "encode"}, "caption": "C-style Hex encode" },
+                            { "command": "hex", "args": {"encode_type": "decode"}, "caption": "C-style Hex decode" }
                         ]
                     }
                 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -75,6 +75,15 @@
                             { "command": "xml", "args": {"encode_type": "escape"}, "caption": "XML escape" },
                             { "command": "xml", "args": {"encode_type": "unescape"}, "caption": "XML unescape" }
                         ]
+                    },
+                    {
+                        "caption": "Hex",
+                        "mnemonic": "C",
+                        "children":
+                        [
+                            { "command": "c_hex", "args": {"encode_type": "encode"}, "caption": "C-style Hex encode" },
+                            { "command": "c_hex", "args": {"encode_type": "decode"}, "caption": "C-style Hex decode" }
+                        ]
                     }
                 ]
             }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Provides a bunch of useful codecs as a Sublime Text plugin to allow you to work 
 - RFC 4627:
     - JSON encoding/decode
     - JSON encoding with escaped Unicode
+- C-style byte strings
 
 ## Limitations
 - Note that this plugin assumes that your file is UTF-8 encoded.

--- a/codec_hex.py
+++ b/codec_hex.py
@@ -1,0 +1,13 @@
+
+import re
+r_hex = re.compile(r'\\x([0-9a-fA-f]{2})')
+
+def decodeHex(hexstring):
+    def func(x):
+        hexval = x.groups()[0]
+        return chr(int(hexval, 16))
+    return r_hex.sub(func, hexstring)
+
+def encodeHex(string):
+    return ''.join(('\\x{0:02x}'.format(ord(char)) for char in string))
+

--- a/codec_hex.py
+++ b/codec_hex.py
@@ -9,5 +9,9 @@ def decodeHex(hexstring):
     return r_hex.sub(func, hexstring)
 
 def encodeHex(string):
+    for c in string:
+        if ord(c) > 255:
+            # non-ascii not supported yet.
+            return string 
     return ''.join(('\\x{0:02x}'.format(ord(char)) for char in string))
 

--- a/sublime_codec.py
+++ b/sublime_codec.py
@@ -13,6 +13,7 @@ if 3 == PYTHON:
     from . import codec_xml
     from . import codec_json
     from . import codec_quopri
+    from . import codec_hex
 else:
     # Python 2 and ST2
     import urllib
@@ -20,6 +21,7 @@ else:
     import codec_xml
     import codec_json
     import codec_quopri
+    import codec_hex
 
 SETTINGS_FILE = "Codec.sublime-settings"
 
@@ -248,5 +250,34 @@ class JsonCommand(sublime_plugin.TextCommand):
             return codec_json.encode_ensure_ascii
         elif 'decode' == encode_type:
             return codec_json.decode
+        else:
+            raise NotImplementedError("unknown encoding type %s" % (str(encode_type),))
+
+
+"""
+Encodes and decodes C-style hex representations of bytes
+
+Hello, my good friend
+encodes to
+\\x48\\x65\\x6c\\x6c\\x6f\\x2c\\x20\\x6d\\x79\\x20\\x67\\x6f\\x6f\\x64\\x20\\x66\\x72\\x69\\x65\\x6e\\x64\\x21
+
+>>> view.run_command('c_hex', {'encode_type': 'encode'})
+"""
+class HexCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit, encode_type='encode'):
+        method = self.get_method(encode_type)
+
+        for region in selected_regions(self.view):
+            if not region.empty():
+                original_string = self.view.substr(region)
+                new_string = method(original_string)
+                self.view.replace(edit, region, new_string)
+
+    def get_method(self, encode_type):
+        if 'encode' == encode_type:
+            return codec_hex.encodeHex
+        elif 'decode' == encode_type:
+            return codec_hex.decodeHex
         else:
             raise NotImplementedError("unknown encoding type %s" % (str(encode_type),))

--- a/tests/test_codec_hex.py
+++ b/tests/test_codec_hex.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8
 import codec_hex
 import unittest
 
@@ -18,4 +19,13 @@ class TestHex(unittest.TestCase):
     def test_nonprintable(self):
         self.assertDecode('\\x00\\x01', '\x00\x01')
         self.assertEncode('\x00\x01\xff', '\\x00\\x01\\xff')
+
+    def test_unicode(self):
+        """
+        For now, unicode is not supported, but if you want to later
+        support unicode, change this test.
+        """
+        self.assertEncode(u'€', u'€')
+        self.assertDecode(u'€', u'€')
+
 

--- a/tests/test_codec_hex.py
+++ b/tests/test_codec_hex.py
@@ -1,0 +1,21 @@
+import codec_hex
+import unittest
+
+class TestHex(unittest.TestCase):
+
+    def assertDecode(self, encoded, expected):
+        actual = codec_hex.decodeHex(encoded)
+        self.assertEqual(expected, actual)
+
+    def assertEncode(self, string, expected):
+        actual = codec_hex.encodeHex(string)
+        self.assertEqual(expected, actual)
+
+    def test_ascii(self):
+        self.assertDecode('\\x20\\x6C', ' l')
+        self.assertEncode('~hello!', '\\x7e\\x68\\x65\\x6c\\x6c\\x6f\\x21')
+
+    def test_nonprintable(self):
+        self.assertDecode('\\x00\\x01', '\x00\x01')
+        self.assertEncode('\x00\x01\xff', '\\x00\\x01\\xff')
+


### PR DESCRIPTION
This code will let you encode/decode C-style hex strings.

```
Hello
```

encodes to

```
\x48\x65\x6c\x6c\x6f
```

You probably don't want to support every encoding in the world, so I won't feel bad if you reject this pull request.  But if you want to include it, please do.  The code isn't tested with Sublime, since I'm not sure how to install this locally (I might spend some time today figuring out how that works).